### PR TITLE
renamed npm module name from xSpinner to xspinner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xSpinner",
+  "name": "xspinner",
   "version": "0.0.1",
   "description": "xSpinner is a CSS Library for animated Loading Spinners.  ",
   "files": [


### PR DESCRIPTION
npm cannot handle uppercase names
